### PR TITLE
Sanitize '$' from the price field when updating a course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -119,12 +119,12 @@ class CoursesController < ApplicationController
 
   def update
     @course = Course.find(params[:id])
+    sanitize_price(params[:course][:price].to_s)
     cat = []
     cat << (params[:course][:categories]).to_s
     params[:course].delete(:categories)
     @course.category_list = cat.join(", ").to_s
     if @course.update_attributes(params[:course])
-      @course.sanitize_price(params[:course][:price].to_s)
       redirect_to preview_path(:id => @course.id)
     else
       render :action => 'edit'
@@ -249,6 +249,12 @@ class CoursesController < ApplicationController
     if @course.status.present? && @course.status != "live"
       redirect_to user_root_path
     end
+  end
+
+  def sanitize_price(price)
+    if !(price =~ /\$/).nil?
+        params[:course][:price] = price.gsub(/\$/, '')
+      end
   end
 
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -164,9 +164,10 @@ class Course < ActiveRecord::Base
      date - Date.today < 0
    end
 
+
    def cropping?
-     !crop_x.blank? && !crop_y.blank? && !crop_w.blank? && !crop_h.blank?
-   end
+       !crop_x.blank? && !crop_y.blank? && !crop_w.blank? && !crop_h.blank?
+     end
 
    def photo_geometry(style = :original)
      @geometry ||= {}
@@ -175,11 +176,8 @@ class Course < ActiveRecord::Base
     @geometry[style] ||= Paperclip::Geometry.from_file(photo.to_file(style))
    end
 
-   def sanitize_price(price)
-     self.update_attributes(:price => price.gsub(/\$/, ''))
-   end
-
    private
+
     def reprocess_photo
       photo.reprocess!
     end


### PR DESCRIPTION
GH Issue #106
# Problem

If a '$' happened to make its way into the `Cover Charge` field when updating a course's info, the updated price would always be $0.
# Fix

This fix enables oblivious users (such as myself) to enter a '$' into the `Cover Charge` field. e.g "$20" instead of "20".

It's a simple regex sanitization of the `:price` param.
