### PR TITLE
Reconnect Facebook Users

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,6 +4,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if current_user
       @user = current_user
       @user.update_facebook_from_oauth(env["omniauth.auth"])
+      cookies[:ignoreFacebookReconnect] = true
     else
       @user = User.find_for_facebook_oauth(env["omniauth.auth"], current_user)
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,41 @@
 <%- end -%>
 
 
+<%- content_for :after_main do  -%>
+
+  <% if cookies[:ignoreFacebookReconnect].blank? && current_user && !current_user.needs_facebook_reconnect?(FacebookPermissions) %>
+    <%= render :layout => 'shared/page/modal', :locals => {
+               :display        => 'block',
+               :modal_class    => 'facebookReconnect',
+               :after_close_js => %Q{$.cookie('ignoreFacebookReconnect',
+                                     true,
+                                     {domain: "#{URI.parse(root_url(:subdomain => nil)).host}",
+                                      path: '/', expires: 365})}} do %>
+      <div>
+        <p>
+          Thanks for using Hourschool, we're trying a new way to make
+          course recommendations and need some permissions from facebook.
+        </p>
+        <br />
+        <p>
+          To take advantage of these new features you can please click on the facebook button:
+        </p>
+        <br />
+        <%= render :partial => 'users/facebook/connect_button' %>
+        <br />
+        <p>
+          You can connect later on your <%= link_to 'settings', edit_user_registration_path %> page.
+        </p>
+        <p>
+          Closing this window to ignore this message
+        </p>
+      </div>
+    <%- end -%>
+  <%- end -%>
+
+<%- end -%>
+
+
 <%= render :layout => 'layouts/document' do %>
   <%= render 'layouts/application/header' %>
 


### PR DESCRIPTION
We changed the permissions needed for some of the Facebook stuff, and need to get people who registered awhile ago to re-connect in order to fix their permissions. This is also a good opportunity to give users who didn't auth with Facebook a chance to connect Facebook to their account. 

This modal will prompt users to connect to Facebook if they have not already done so. If they have connected Facebook, but don't have updated permissions they will also prompted to re-connect. If the user re-connects or dismisses the modal window then they will not see it again.

http://cl.ly/1w1A2X2a1f0x3y022Q1U
