### PR TITLE
Add twitter_id to auto-tweet if message < 140 chars

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -265,7 +265,14 @@ class CoursesController < ApplicationController
 
   def post_to_twitter(course)
     client = Twitter::Client.new
-    client.update("New class available in ##{course.city.name}! Sign up for \"#{course.title}\" here: #{url_for(course)}")
+    if !current_user.twitter_id.blank?
+      message = "New class available in ##{course.city.name}! Sign up for \"#{course.title}\" taught by @#{current_user.twitter_id} "
+      if message.size < 125
+        client.update(message + url_for(course))
+      end
+    else
+      client.update("New class available in ##{course.city.name}! Sign up for \"#{course.title}\" here: #{url_for(course)}")
+    end
   end
 
   def sanitize_price(price)


### PR DESCRIPTION
#117

Wanted to give everyone a chance to take a look at this before I pushed to master.
## 

If the tweet with the teacher's twitter_id is < 125 chars use that one, otherwise default back to the old tweet.

I used 125 chars as a upper bound in order to have enough chars left for the url.
## 

LF Feedback on code style
