### PR TITLE
initial pass paypal payments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ group :assets do
   # gem 'compass-rails',      :git => 'git://github.com/Compass/compass-rails.git'
 end
 
+
+gem 'paypal-express'
+gem "paypal-recurring"
+
 gem 'sass-rails',           '~> 3.2.4'
 
 gem 'pg',                   '~> 0.12.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       activesupport
       builder
     arel (3.0.2)
+    attr_required (0.0.5)
     awesome_print (1.0.2)
     aws-s3 (0.6.2)
       builder
@@ -281,6 +282,12 @@ GEM
       activesupport (>= 2.3.2)
       cocaine (>= 0.0.2)
       mime-types
+    paypal-express (0.4.6)
+      activesupport (>= 2.3)
+      attr_required (>= 0.0.5)
+      i18n
+      restclient_with_cert
+    paypal-recurring (0.1.6)
     pg (0.12.2)
     pgbackup-tasks (0.2.3)
       heroku (>= 2.17.0)
@@ -326,6 +333,8 @@ GEM
     responders (0.6.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
+    restclient_with_cert (0.0.8)
+      rest-client (>= 1.6)
     rinku (1.2.2)
     rsolr (1.0.7)
       builder (>= 2.1.2)
@@ -468,6 +477,8 @@ DEPENDENCIES
   newrelic_rpm (~> 3.3.1)
   omniauth (~> 0.3.2)
   paperclip (~> 2.5.0)
+  paypal-express
+  paypal-recurring
   pg (~> 0.12.2)
   pgbackup-tasks (~> 0.2.3)
   progress_bar

--- a/app/controllers/payments/paypal/requests_controller.rb
+++ b/app/controllers/payments/paypal/requests_controller.rb
@@ -1,0 +1,23 @@
+# This controller creates the PayPal Request
+# if successful, the user will be redirected back to
+# the paypal response
+
+
+# Note: that `paypal` and `request_for_course` are in paypal_controller.rb
+
+
+class Payments::Paypal::RequestsController < Payments::PaypalController
+  before_filter :authenticate_user!
+
+
+  def create
+    @course = Course.find(params[:course_id])
+    payment_request = request_for_course(@course)
+
+    success_url = payments_paypal_responses_url(:course_id => @course)
+    cancel_url  = course_url(@course)
+    paypal_response = paypal.setup(payment_request, success_url, cancel_url) # response = request.setup(payment_request,YOUR_SUCCESS_CALBACK_URL,YOUR_CANCEL_CALBACK_URL)
+    redirect_to paypal_response.redirect_uri
+  end
+
+end

--- a/app/controllers/payments/paypal/responses_controller.rb
+++ b/app/controllers/payments/paypal/responses_controller.rb
@@ -1,0 +1,37 @@
+# This controller creates the PayPal Response
+# Note: that `paypal` and `request_for_course` are in paypal_controller.rb
+
+class Payments::Paypal::ResponsesController < Payments::PaypalController
+  before_filter :authenticate_user!
+
+  def create
+    @course   = Course.find(params[:course_id])
+    token     = params[:token]
+    payer_id  = params[:PayerID]
+
+    payment_request = request_for_course(@course)
+
+    details = paypal.details(token)
+    # payment_response = paypal.details(token)
+    paypal.checkout!(token, payer_id, payment_request)
+
+    @payment = Payment.new(
+      :transaction_amount => details.amount.total.to_s,
+      :transaction_id     => token,
+      :user               => current_user,
+      :course             => @course
+    )
+
+     if @payment.save
+        @user = current_user
+        @role = @course.roles.create!(:attending => true, :name => 'student', :user => current_user)
+        UserMailer.send_course_registration_mail(current_user.email, current_user.name, @course).deliver
+        UserMailer.send_course_registration_to_teacher_mail(current_user.email, current_user.name, @course).deliver
+        flash[:notice] = "You're registered!!!"
+        redirect_to course_confirm_path(:id => @course.id)
+    else
+      redirect_to @course, :notice => "Sorry you couldn't make it this time. Next time?"
+    end
+  end
+
+end

--- a/app/controllers/payments/paypal_controller.rb
+++ b/app/controllers/payments/paypal_controller.rb
@@ -1,0 +1,19 @@
+class Payments::PaypalController < ApplicationController
+
+
+  def paypal
+     Paypal::Express::Request.new(
+      :username   => PAYPAL_USERNAME,
+      :password   => PAYPAL_PASSWORD,
+      :signature  => PAYPAL_SIGNATURE
+    )
+  end
+  
+  def request_for_course(course)
+    Paypal::Payment::Request.new(
+      :description   => course.description,
+      :amount        => course.price,
+    )
+  end
+
+end

--- a/app/views/payments/paypal/requests/new.html.erb
+++ b/app/views/payments/paypal/requests/new.html.erb
@@ -1,0 +1,7 @@
+<% @course = Course.find(85) %>
+
+<%= "Pay: #{@course.price}" %>
+<div id="paypal_checkout" style="">
+  <%= link_to image_tag("https://www.paypal.com/en_US/i/btn/btn_xpressCheckout.gif"), payments_paypal_requests_path(:course_id => @course.id), :method => :POST %>
+  </div>
+</div>

--- a/config/initializers/paypal.rb
+++ b/config/initializers/paypal.rb
@@ -1,0 +1,16 @@
+if Rails.env.production?
+
+else
+  Paypal.sandbox!
+  PAYPAL_USERNAME   = "richar_1334798699_biz_api1.heroku.com"
+  PAYPAL_PASSWORD   = "1334798723"
+  PAYPAL_SIGNATURE  = "AL0M4ALm2V5nIrWDqJdRfE8TCsK5A36Aq.CUapE2nUVD1Qj2i.yNZJWd"
+end
+
+
+PayPal::Recurring.configure do |config|
+  config.sandbox    = true
+  config.username   = PAYPAL_USERNAME
+  config.password   = PAYPAL_PASSWORD
+  config.signature  = PAYPAL_SIGNATURE
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,15 @@ HourschoolV2::Application.routes.draw do
     resources :search
   end
 
+  namespace :payments do
+    namespace :paypal do
+      resources :requests,  :only => [:new, :create]
+      resources :responses, :only => [:create]
+    end
+  end
+
+  match '/payments/paypal/responses' => 'Payments::Paypal::Responses#create'
+
   resources :courses do
     resources :owner, :controller => 'courses/owner'
   end
@@ -86,7 +95,7 @@ HourschoolV2::Application.routes.draw do
 
   match '/proposal'                   => 'courses#show_proposal'
   match '/approve'                    => 'courses#approve'
-    
+
   match '/courses-proposals'          => 'courses#proposals', :as => 'course_proposals'
   match '/courses-pending-live'       => 'courses#pending_live', :as => 'course_pending_live'
 

--- a/doc/paypal.md
+++ b/doc/paypal.md
@@ -1,0 +1,46 @@
+
+https://github.com/nov/paypal-express/wiki/Instant-Payment
+
+## Request
+
+To create a new paypal request go to localhost:3000/payments/paypal/requests/new
+
+Click on the button, you should be redirected to paypal and asked to log in.
+
+
+
+## Test accounts
+
+
+You can use make a new test account by going to https://developer.paypal.com
+
+
+Then change the credentials in config/paypal.rb
+
+### Or
+
+You can use my test user richar_1334798373_per@heroku.com
+
+with password: 334798373
+
+
+## Response
+
+Paypal will return a response back to the payments/paypal/response controller and hit the create action.
+
+
+
+## TODO
+
+You need to sign up for an authenticated account with paypal, add the credentials to the config/initializers/paypal.rb (inside of the production case).
+
+
+Add the pay with paypal button anywhere you like (copy from payments/paypal/requests/new.html)
+
+
+Deploy
+
+
+Test
+
+Smile :)


### PR DESCRIPTION
Added paypal in this branch. Using the horrible paypal-express gem

https://github.com/nov/paypal-express/wiki/Instant-Payment
## Request

To create a new paypal request go to localhost:3000/payments/paypal/requests/new

Click on the button, you should be redirected to paypal and asked to log in.
## Test accounts

You can use make a new test account by going to https://developer.paypal.com

Then change the credentials in config/paypal.rb
### Or

You can use my test user richar_1334798373_per@heroku.com

with password: 334798373
## Response

Paypal will return a response back to the payments/paypal/response controller and hit the create action.
## TODO

You need to sign up for an authenticated account with paypal, add the credentials to the config/initializers/paypal.rb (inside of the production case).

Deploy

Test

Add the pay with paypal button anywhere you like (copy from payments/paypal/requests/new.html)

Deploy again with fully working site that accepts paypal

Smile :)
